### PR TITLE
use the jQuery instead of $

### DIFF
--- a/waypoint-animation.js
+++ b/waypoint-animation.js
@@ -7,7 +7,7 @@
     define(['jquery', 'requestAnimationFrame'], factory);
   } else {
     // Browser globals
-    root.WaypointAnimation = factory(root.$);
+    root.WaypointAnimation = factory(root.jQuery);
   }
 }(this, function ($) {
   // functions


### PR DESCRIPTION
The current implementation does not work with `$.noConflict();` active. This small change makes this script more portable.
